### PR TITLE
Add meta endpoint `$canAccess` for every api root, to allow checking …

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/passport": "0.3.3",
     "@types/passport-local": "1.0.30",
     "@types/pg": "6.1.43",
+    "@types/request": "^2.0.8",
     "@types/websql": "0.0.27",
     "coffee-loader": "^0.7.2",
     "extract-text-webpack-plugin": "^1.0.1",

--- a/src/config-loader/config-loader.coffee
+++ b/src/config-loader/config-loader.coffee
@@ -2,7 +2,6 @@ _ = require 'lodash'
 Promise = require 'bluebird'
 sbvrUtils = require '../sbvr-api/sbvr-utils'
 permissions = require '../sbvr-api/permissions'
-resourceaccess = require '../sbvr-api/resource-access'
 fs = Promise.promisifyAll(require('fs'))
 
 # Setup function
@@ -94,7 +93,6 @@ exports.setup = (app) ->
 				Promise.map data.models, (model) ->
 					if model.modelText?
 						apiRoute = '/' + model.apiRoot + '/*'
-						app.post('/' + model.apiRoot + '/([\$])canAccess', sbvrUtils.authorizationMiddleware, resourceaccess.canAccessV1Request)
 						app.options(apiRoute, (req, res) -> res.sendStatus(200))
 						app.all(apiRoute, sbvrUtils.handleODataRequest)
 

--- a/src/config-loader/config-loader.coffee
+++ b/src/config-loader/config-loader.coffee
@@ -2,6 +2,7 @@ _ = require 'lodash'
 Promise = require 'bluebird'
 sbvrUtils = require '../sbvr-api/sbvr-utils'
 permissions = require '../sbvr-api/permissions'
+resourceaccess = require '../sbvr-api/resource-access'
 fs = Promise.promisifyAll(require('fs'))
 
 # Setup function
@@ -93,6 +94,7 @@ exports.setup = (app) ->
 				Promise.map data.models, (model) ->
 					if model.modelText?
 						apiRoute = '/' + model.apiRoot + '/*'
+						app.post('/' + model.apiRoot + '/([\$])canAccess', sbvrUtils.authorizationMiddleware, resourceaccess.canAccessV1Request)
 						app.options(apiRoute, (req, res) -> res.sendStatus(200))
 						app.all(apiRoute, sbvrUtils.handleODataRequest)
 

--- a/src/sbvr-api/resource-access.ts
+++ b/src/sbvr-api/resource-access.ts
@@ -29,7 +29,7 @@ interface PermissionHolder {
 
 function manipulatePermissions(originalPermissions: string[], resource: string, action: string): string[] {
 	const targetActionPermissions = `resin.${resource}.${action}`;
-	let permissionsInQuestion: string[] = [];
+	const permissionsInQuestion: string[] = [];
 	originalPermissions.forEach((permission: string) => {
 		if(_.startsWith(permission, targetActionPermissions)) {
 			const rewrittenPermission = `resin.${resource}.read` + permission.slice(targetActionPermissions.length);

--- a/src/sbvr-api/resource-access.ts
+++ b/src/sbvr-api/resource-access.ts
@@ -1,0 +1,153 @@
+import * as express from 'express'
+import * as _ from 'lodash'
+import * as Promise from 'bluebird'
+import TypedError = require('typed-error')
+import { AnyObject } from 'pinejs-client/core';
+import PinejsClient = require('pinejs-client');
+
+class BadInputError extends TypedError {}
+class UnauthorizedError extends TypedError {}
+
+const sbvrUtils = require('./sbvr-utils');
+
+const getAPIClient: GetAPIClient = sbvrUtils.getAPIClient as GetAPIClient
+
+interface GetAPIClient {
+	(vocab: string): PinejsClient
+}
+
+interface Authenticator {
+	apiKey?: PermissionHolder
+	user?: PermissionHolder
+}
+
+interface PermissionHolder {
+	actor?: number
+	key?: string
+	permissions: string[]
+}
+
+function manipulatePermissions(originalPermissions: string[], resource: string, action: string): string[] {
+	const targetActionPermissions = `resin.${resource}.${action}`;
+	let permissionsInQuestion: string[] = [];
+	originalPermissions.forEach((permission: string) => {
+		if(_.startsWith(permission, targetActionPermissions)) {
+			const rewrittenPermission = `resin.${resource}.read` + permission.slice(targetActionPermissions.length);
+			permissionsInQuestion.push(rewrittenPermission);
+		}
+	});
+	return permissionsInQuestion;
+}
+
+function validateParameters(resource: string, action: string, id: number): void {
+	const RESOURCE_VALIDATOR = /^[a-z][a-z_]+[a-z]$/g
+	const ACTION_VALIDATOR = /^[a-z]+$/g
+
+	if (!RESOURCE_VALIDATOR.test(resource)) {
+		throw new BadInputError('Invalid resource parameter');
+	}
+
+	if (!ACTION_VALIDATOR.test(action)) {
+		throw new BadInputError('Invalid resource parameter');
+	}
+
+	if (_.isNaN(id) || id < 1) {
+		throw new BadInputError('Invalid id value');
+	}
+}
+
+export function checkAccessForResourceWithRequest(req: express.Request, api: PinejsClient, resource: string, action: string, id: number): Promise<void> {
+	if (req.user != null) {
+		return checkAccessForResource(req.user as PermissionHolder, api, resource, action, id);
+	} else if (req.apiKey != null) {
+		return checkAccessForResource(req.apiKey, api, resource, action, id);
+	}
+	return Promise.reject(new UnauthorizedError());
+}
+
+export function checkAccessForResource(user: PermissionHolder, api: PinejsClient, resource: string, action: string, id: number): Promise<void> {
+
+	// validate parameters
+	validateParameters(resource, action, id);
+
+	// Cloning original user object, to keep real permissions intact
+	// to allow further use of the request.
+	const clonedUser = _.cloneDeep(user);
+	clonedUser.permissions = manipulatePermissions(clonedUser.permissions, resource, action);
+
+	const authenticator: Authenticator = {}
+	if (clonedUser.actor === undefined) {
+		// this is an apiKey authentication entry
+		authenticator.apiKey = clonedUser
+	} else {
+		// this is an user authentication entry
+		authenticator.user = clonedUser
+	}
+
+	// Try to read resource with augmented pine permissions
+	return api.get({
+		resource: resource,
+		id: id,
+		options: {
+			$select: 'id'
+		},
+		passthrough: {
+			req: authenticator
+		}
+	})
+	.then((instance) => {
+		instance = instance as AnyObject
+		if(instance != null && instance.id == id) {
+			// OK
+			return;
+		}
+		throw new UnauthorizedError(`Access to resource for ${action} not allowed`);
+	})
+	.catch((err) => {
+		if (err == 401) {
+			throw new UnauthorizedError(`Access to resource for ${action} not allowed`);
+		}
+		if (_.isNumber(err)) {
+			throw new TypedError(`PineAPI threw error number: ${err}`);
+		}
+		throw err;
+	});
+}
+
+export function canAccessV1Request(req: express.Request, res: express.Response, next: express.NextFunction): void {
+	const url = req.url.split('/')
+	const apiRoot = url[1]
+	const api = getAPIClient(apiRoot);
+	if (api == null)
+		return next('route')
+
+	Promise.try( () => {
+		const resource: string = _.get(req.body, 'resource');
+		const action: string = _.get(req.body, 'action');
+		const idString: string = _.get(req.body, 'id');
+
+		if (resource === undefined || action === undefined || idString === undefined) {
+			throw new BadInputError('Missing parameters');
+		}
+
+		const id: number = parseInt(idString);
+
+		return checkAccessForResourceWithRequest(req, api, resource, action, id);
+	})
+	.then( () => {
+		res.sendStatus(200);
+	})
+	.catch( (err) => {
+		if (err instanceof UnauthorizedError) {
+			res.sendStatus(401);
+			return;
+		}
+
+		if (err instanceof BadInputError) {
+			res.sendStatus(400);
+			return;
+		}
+
+		res.sendStatus(500);
+	});
+}

--- a/src/sbvr-api/sbvr-utils.coffee
+++ b/src/sbvr-api/sbvr-utils.coffee
@@ -559,6 +559,11 @@ exports.runRule = do ->
 					return result
 		.nodeify(callback)
 
+exports.getAPIClient = (vocab) ->
+	if !vocab? or !abstractSqlModels[vocab]?
+		return
+	return api[vocab]
+
 exports.PinejsClient =
 	class PinejsClient extends PinejsClientCore(_, Promise)
 		_request: ({ method, url, body, tx, req, custom }) ->

--- a/src/sbvr-api/sbvr-utils.coffee
+++ b/src/sbvr-api/sbvr-utils.coffee
@@ -633,7 +633,6 @@ exports.handleODataRequest = handleODataRequest = (req, res, next) ->
 	# value of apiRoot is an actual apiRoot. Otherwise this might allow users
 	# to build a regex from their provided input.
 	if req.method == 'POST' && api[apiRoot] != null && new RegExp(apiRoot + '\/\\$canAccess$').test(req.url)
-		api[apiRoot].logger.log('Running custom $canAccess endpoint')
 		return exports.authorizationMiddleware(req, res)
 		.then ->
 			resourceAccess.canAccessV1Request(api[apiRoot], req, res, next)

--- a/src/sbvr-api/uri-parser.coffee
+++ b/src/sbvr-api/uri-parser.coffee
@@ -33,7 +33,7 @@ memoizedOdata2AbstractSQL = do ->
 		_.assign(body, extraBodyVars)
 		return _.cloneDeep(tree)
 
-exports.metadataEndpoints = metadataEndpoints = ['$metadata', '$serviceroot']
+exports.metadataEndpoints = metadataEndpoints = ['$metadata', '$serviceroot', '$canAccess']
 
 notBadRequestOrParsingError = (e) ->
 	not ((e instanceof BadRequestError) or (e instanceof ParsingError))

--- a/typings/express-extension.d.ts
+++ b/typings/express-extension.d.ts
@@ -1,0 +1,8 @@
+declare namespace Express {
+	export interface Request {
+		apiKey?: {
+			permissions: string[]
+			key: string
+		}
+	}
+}


### PR DESCRIPTION
…resource access for arbitrary actions

This adds an `$canAccess` endpoint to every api root. This endpoint accepts POST requests
with parameters `resource`, `action` and `id`.
- The `resource` parameter holds the resource name in question.
- The `action` parameter holds the action in question.
- The `id` parameter holds the resource id in question.

The endpoint responds with an empty response with http status code 200 if access is granted.
The endpoint responds with an http status code 401 if access is not granted.
The endpoint can also respond with http status code 400 or 500 in case of client or server errors.

Change-Type: minor
Connects-To: #91
Signed-off-by: Andreas Fitzek <andreas@resin.io>
---- Autogenerated Waffleboard Connection: Connects to #91