### PR TITLE
Compile Typescript to es2015, which changes the minimum requirement t…

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/passport": "^0.3.3",
     "@types/passport-local": "^1.0.30",
     "@types/pg": "^6.1.43",
+    "@types/request": "^2.0.8",
     "@types/websql": "^0.0.27",
     "coffee-loader": "^0.7.2",
     "extract-text-webpack-plugin": "^1.0.1",
@@ -88,7 +89,7 @@
     "ts-node": "^3.0.4"
   },
   "engines": {
-    "node": ">=4.0.0",
+    "node": ">=6.5.0",
     "npm": ">=3.0.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
 		"removeComments": true,
 		"rootDir": "src",
 		"sourceMap": true,
-		"strictNullChecks": true
+		"strictNullChecks": true,
+		"target": "es2015"
 	},
 	"include": [
 		"src/**/*.ts",


### PR DESCRIPTION
…o node >=6.5.0

This fixes the typescript compiler errors.

Change-Type: major
Signed-off-by: Andreas Fitzek <andreas@resin.io>