### PR TITLE
Add a migrations lock so only one pinejs instance will run migrations

### DIFF
--- a/migrations/8.3.0-fix-migration-primary-key.sql
+++ b/migrations/8.3.0-fix-migration-primary-key.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "migration"
+ADD PRIMARY KEY ("model name");

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   },
   "dependencies": {
     "@resin/abstract-sql-compiler": "^5.3.3",
-    "@resin/lf-to-abstract-sql": "^2.0.6",
+    "@resin/lf-to-abstract-sql": "^2.0.7",
     "@resin/odata-parser": "^0.3.6",
-    "@resin/odata-to-abstract-sql": "^2.2.3",
+    "@resin/odata-to-abstract-sql": "^2.2.5",
     "@resin/sbvr-parser": "^0.1.4",
     "@resin/sbvr-types": "^1.4.2",
     "@types/bluebird": "^3.5.24",
@@ -40,10 +40,10 @@
     "coffee-script": "~1.12.2",
     "deep-freeze": "0.0.1",
     "express-session": "^1.10.3",
-    "lodash": "^4.0.0",
+    "lodash": "^4.17.11",
     "memoizee": "^0.4.14",
     "ometa-js": "^1.5.3",
-    "pinejs-client-core": "^5.3.3",
+    "pinejs-client-core": "^5.3.4",
     "typed-error": "^2.0.0"
   },
   "devDependencies": {

--- a/src/config-loader/env.ts
+++ b/src/config-loader/env.ts
@@ -24,3 +24,9 @@ export const db = {
 	poolSize: 50,
 	idleTimeoutMillis: 30000,
 }
+
+export const migrator = {
+	lockTimeout: 5 * 60 * 1000,
+	// Used to delay the failure on lock taking, to avoid spam taking
+	lockFailDelay: 20 * 1000,
+}

--- a/src/migrator/migrations.sbvr
+++ b/src/migrator/migrations.sbvr
@@ -1,14 +1,23 @@
 Vocabulary: migrations
 
-Term:       model name
+Term: model name
 	Concept Type: Short Text (Type)
-Term:       executed migrations
+Term: executed migrations
 	Concept Type: JSON (Type)
+Term: lock time
+	Concept Type: Date Time (Type)
 
-Term:       migration
-	Reference Scheme:   model name
-	Database ID Field:  model name
-Fact Type:  migration has model name
+Term: migration
+	Reference Scheme: model name
+	Database ID Field: model name
+Fact Type: migration has model name
 	Necessity: each migration has exactly one model name
-Fact Type:  migration has executed migrations
+Fact Type: migration has executed migrations
 	Necessity: each migration has exactly one executed migrations
+
+Term: migration lock
+	Reference Scheme: model name
+	Database ID Field: model name
+
+Fact Type: migration lock has model name
+	Necessity: each migration lock has exactly one model name


### PR DESCRIPTION
Depends on https://github.com/resin-io/lf-to-abstract-sql/pull/21

Change-type: minor
Signed-off-by: Pagan Gazzard <page@resin.io>