### PR TITLE
Resolve the root argument as an absolute path

### DIFF
--- a/src/config-loader/config-loader.ts
+++ b/src/config-loader/config-loader.ts
@@ -234,7 +234,7 @@ export const setup = (app: _express.Application) => {
 		let root: string
 		let configObj: Config
 		if (config == null) {
-			root = process.argv[2] || __dirname
+			root = path.resolve(process.argv[2]) || __dirname
 			configObj = loadJSON(path.join(root, 'config.json'))
 		} else if (_.isString(config)) {
 			root = path.dirname(config)


### PR DESCRIPTION
This fixes issues with requiring when it's a relative path

Change-type: patch
Signed-off-by: Pagan Gazzard <page@resin.io>